### PR TITLE
feat: require CONNECT_CLIENT_VERSION build arg

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,11 +9,18 @@ on:
         description: 'Tag to use for the images (e.g., v1.0.0)'
         required: true
         type: string
+      connect_client_version:
+        description: 'Version of connect-client to use (e.g., 0.8)'
+        required: true
+        type: string
+        default: '0.8'
 
 env:
   REGISTRY: ghcr.io
   # Use release tag for releases, or input tag for manual runs
   IMAGE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.tag }}
+  # Use provided connect-client version or default to 0.8
+  CONNECT_CLIENT_VERSION: ${{ inputs.connect_client_version || '0.8' }}
 
 jobs:
   build-and-push:
@@ -52,6 +59,8 @@ jobs:
         with:
           context: ${{ matrix.container.path }}
           push: true
+          build-args: |
+            CONNECT_CLIENT_VERSION=${{ env.CONNECT_CLIENT_VERSION }}
           tags: |
             ${{ env.REGISTRY }}/${{ github.repository }}/${{ matrix.container.name }}:${{ env.IMAGE_TAG }}
             ${{ env.REGISTRY }}/${{ github.repository }}/${{ matrix.container.name }}:latest

--- a/cellxgene/Dockerfile
+++ b/cellxgene/Dockerfile
@@ -1,7 +1,8 @@
 # ---------------------------------------------------------------
 # 1) Multi-stage build: Pull the connect-client binary
 # ---------------------------------------------------------------
-FROM public.cr.seqera.io/platform/connect-client:0.8 AS connect
+ARG CONNECT_CLIENT_VERSION
+FROM public.cr.seqera.io/platform/connect-client:${CONNECT_CLIENT_VERSION} AS connect
 
 # ---------------------------------------------------------------
 # 2) Additional base image for CellxGene

--- a/cellxgene/README.md
+++ b/cellxgene/README.md
@@ -8,6 +8,7 @@ This example provides a custom container image for running [CellxGene](https://c
 - [Features](#features)
 - [Files](#files)
 - [Prerequisites](#prerequisites)
+- [Building the Container](#building-the-container)
 - [Local Testing](#local-testing)
 - [Using in Seqera Studios](#using-in-seqera-studios)
 - [Notes](#notes)
@@ -51,12 +52,22 @@ For specific versions, use the release tag (e.g., `ghcr.io/seqeralabs/custom-stu
 Additional requirements specific to this example:
 - .h5ad format single-cell datasets
 
-## Local Testing
+## Building the Container
 
-To test the app locally:
+> [!IMPORTANT]
+> You must provide the `CONNECT_CLIENT_VERSION` build argument when building the container.
+
+To build the container locally:
 
 ```bash
-docker build --platform=linux/amd64 -t cellxgene-example .
+docker build --platform=linux/amd64 --build-arg CONNECT_CLIENT_VERSION=0.8 -t cellxgene-example .
+```
+
+## Local Testing
+
+To test the app locally, you need to override the entrypoint:
+
+```bash
 docker run -p 3000:3000 --entrypoint /usr/local/bin/cellxgene cellxgene-example launch \
     --host 0.0.0.0 \
     --port 3000 \
@@ -66,8 +77,7 @@ docker run -p 3000:3000 --entrypoint /usr/local/bin/cellxgene cellxgene-example 
     /path/to/your/dataset.h5ad
 ```
 
-To use a specific data file, make it available at /workspace/data/cellxgene_datasets/ in the 
-container:
+To use a specific data file, make it available at /workspace/data/cellxgene_datasets/ in the container:
 
 ```bash
 docker run -p 3000:3000 --entrypoint /usr/local/bin/cellxgene -v $(pwd)/data:/workspace/data/cellxgene_datasets cellxgene-example launch \

--- a/marimo/Dockerfile
+++ b/marimo/Dockerfile
@@ -1,4 +1,8 @@
-FROM public.cr.seqera.io/platform/connect-client:0.7 AS connect
+# ---------------------------------------------------------------
+# 1) Multi-stage build: Pull the connect-client binary
+# ---------------------------------------------------------------
+ARG CONNECT_CLIENT_VERSION
+FROM public.cr.seqera.io/platform/connect-client:${CONNECT_CLIENT_VERSION} AS connect
 
 # Choose a python version that you know works with your application
 FROM python:3.11-slim

--- a/marimo/README.md
+++ b/marimo/README.md
@@ -44,16 +44,13 @@ This container is designed for use as a [custom Studio environment](https://docs
 
 ## Building the Container
 
+> [!IMPORTANT]
+> You must provide the `CONNECT_CLIENT_VERSION` build argument when building the container.
+
 To build the container locally:
 
 ```sh
-wave -f Dockerfile --await
-```
-
-Or, using Docker directly:
-
-```sh
-docker build -t marimo-studio .
+docker build --platform=linux/amd64 --build-arg CONNECT_CLIENT_VERSION=0.8 -t marimo-studio .
 ```
 
 > [!NOTE]

--- a/shiny-simple-example/Dockerfile
+++ b/shiny-simple-example/Dockerfile
@@ -1,7 +1,8 @@
 # ---------------------------------------------------------------
 # 1) Multi-stage build: Pull the connect-client binary
 # ---------------------------------------------------------------
-FROM public.cr.seqera.io/platform/connect-client:0.8 AS connect
+ARG CONNECT_CLIENT_VERSION
+FROM public.cr.seqera.io/platform/connect-client:${CONNECT_CLIENT_VERSION} AS connect
 
 # ---------------------------------------------------------------
 # 2) Final stage: Ubuntu + micromamba + r-shiny

--- a/shiny-simple-example/README.md
+++ b/shiny-simple-example/README.md
@@ -8,6 +8,7 @@ This example provides a custom container image for running a [R Shiny](https://s
 - [Features](#features)
 - [Files](#files)
 - [Prerequisites](#prerequisites)
+- [Building the Container](#building-the-container)
 - [Local Testing](#local-testing)
 - [Using in Seqera Studios](#using-in-seqera-studios)
 - [Notes](#notes)
@@ -50,12 +51,22 @@ For specific versions, use the release tag (e.g., `ghcr.io/seqeralabs/custom-stu
 - Access to a container registry (public or Amazon ECR) if you wish to push your image
 - R data files in CSV format
 
-## Local Testing
+## Building the Container
 
-To test the app locally:
+> [!IMPORTANT]
+> You must provide the `CONNECT_CLIENT_VERSION` build argument when building the container.
+
+To build the container locally:
 
 ```bash
-docker build --platform=linux/amd64 -t shiny-simple-example .
+docker build --platform=linux/amd64 --build-arg CONNECT_CLIENT_VERSION=0.8 -t shiny-simple-example .
+```
+
+## Local Testing
+
+To test the app locally, you need to override the entrypoint:
+
+```bash
 docker run -p 3000:3000 --entrypoint micromamba shiny-simple-example run -n shiny R -e "shiny::runApp('/app/app_plot_demo.R', host='0.0.0.0', port=3000)"
 ```
 

--- a/streamlit/Dockerfile
+++ b/streamlit/Dockerfile
@@ -1,7 +1,8 @@
 # ---------------------------------------------------------------
 # 1) Multi-stage build: Pull the connect-client binary
 # ---------------------------------------------------------------
-    FROM public.cr.seqera.io/platform/connect-client:0.8 AS connect
+ARG CONNECT_CLIENT_VERSION
+FROM public.cr.seqera.io/platform/connect-client:${CONNECT_CLIENT_VERSION} AS connect
 
 # ---------------------------------------------------------------
 # 2) Additional base image for Streamlit

--- a/streamlit/README.md
+++ b/streamlit/README.md
@@ -8,6 +8,7 @@ This example provides a custom container image for running a [Streamlit](https:/
 - [Features](#features)
 - [Files](#files)
 - [Prerequisites](#prerequisites)
+- [Building the Container](#building-the-container)
 - [Local Testing](#local-testing)
 - [Using in Seqera Studios](#using-in-seqera-studios)
 - [Notes](#notes)
@@ -47,12 +48,22 @@ For specific versions, use the release tag (e.g., `ghcr.io/seqeralabs/custom-stu
 - Access to a container registry (public or Amazon ECR) if you wish to push your image
 - MultiQC data files for visualization
 
-## Local Testing
+## Building the Container
 
-To test the app locally:
+> [!IMPORTANT]
+> You must provide the `CONNECT_CLIENT_VERSION` build argument when building the container.
+
+To build the container locally:
 
 ```bash
-docker build --platform=linux/amd64 -t streamlit-example .
+docker build --platform=linux/amd64 --build-arg CONNECT_CLIENT_VERSION=0.8 -t streamlit-example .
+```
+
+## Local Testing
+
+To test the app locally, you need to override the entrypoint:
+
+```bash
 docker run -p 3000:3000 --entrypoint streamlit streamlit-example run /app/multiqc_app.py \
     --server.port=3000 \
     --server.address=0.0.0.0 \

--- a/ttyd/Dockerfile
+++ b/ttyd/Dockerfile
@@ -1,5 +1,8 @@
-# Stage 1: Get the Seqera Connect client
-FROM public.cr.seqera.io/platform/connect-client:0.8 AS connect
+# ---------------------------------------------------------------
+# 1) Multi-stage build: Pull the connect-client binary
+# ---------------------------------------------------------------
+ARG CONNECT_CLIENT_VERSION
+FROM public.cr.seqera.io/platform/connect-client:${CONNECT_CLIENT_VERSION} AS connect
 
 # Final image: Start from an arbitrary container
 FROM community.wave.seqera.io/library/samtools:1.21--0d76da7c3cf7751c

--- a/ttyd/README.md
+++ b/ttyd/README.md
@@ -8,6 +8,7 @@ This example provides a custom container image for running an interactive termin
 - [Features](#features)
 - [Files](#files)
 - [Prerequisites](#prerequisites)
+- [Building the Container](#building-the-container)
 - [Local Testing](#local-testing)
 - [Using in Seqera Studios](#using-in-seqera-studios)
 - [Notes](#notes)
@@ -49,12 +50,22 @@ For specific versions, use the release tag (e.g., `ghcr.io/seqeralabs/custom-stu
 
 No additional prerequisites specific to this example.
 
-## Local Testing
+## Building the Container
 
-To test the terminal locally:
+> [!IMPORTANT]
+> You must provide the `CONNECT_CLIENT_VERSION` build argument when building the container.
+
+To build the container locally:
 
 ```bash
-docker build --platform=linux/amd64 -t ttyd-example .
+docker build --platform=linux/amd64 --build-arg CONNECT_CLIENT_VERSION=0.8 -t ttyd-example .
+```
+
+## Local Testing
+
+To test the terminal locally, you need to override the entrypoint:
+
+```bash
 docker run -p 3000:3000 --entrypoint ttyd ttyd-example -W -p 3000 bash
 ```
 


### PR DESCRIPTION
Edited Dockerfiles at @robnewman 's suggestion, to use build args for Connect client version. I'm going to merge this quickly bypassing review, because it needs to be compliant with the Blog being released shortly.  

- Remove default values from ARGs in all Dockerfiles
- Update READMEs to separate build and test instructions
- Add prominent warning about required CONNECT_CLIENT_VERSION
- Update GitHub Actions workflow to include CONNECT_CLIENT_VERSION
- Add input parameter for manual workflow runs
- Make build commands consistent across all examples