### PR TITLE
feat: add Renovate for automated dependency updates

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,6 +13,7 @@ on:
         description: 'Version of connect-client to use (e.g., 0.9)'
         required: true
         type: string
+        # renovate: datasource=docker depName=public.cr.seqera.io/platform/connect-client
         default: '0.9'
 
 env:

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,21 @@
+name: Renovate
+
+on:
+  # Run weekly on Monday mornings
+  schedule:
+    - cron: '0 5 * * 1'
+  # Allow manual trigger
+  workflow_dispatch:
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run Renovate
+        uses: renovatebot/github-action@v41.0.10
+        with:
+          configurationFile: renovate.json
+          token: ${{ secrets.RENOVATE_TOKEN }}

--- a/.opencode/skills/renovate/SKILL.md
+++ b/.opencode/skills/renovate/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: renovate
+description: >
+  Run Renovate CLI for dependency updates. Use when checking for outdated dependencies,
+  testing Renovate config, or manually triggering dependency update PRs in a repository.
+---
+
+# Renovate CLI Skill
+
+Renovate is a dependency update tool that can automatically create PRs for outdated dependencies. This skill covers running Renovate locally via CLI for testing, debugging, and manual updates.
+
+## When to Use Renovate CLI
+
+**Use Renovate CLI when:**
+- Testing a `renovate.json` configuration before deploying
+- Debugging why Renovate isn't detecting certain dependencies
+- Manually triggering dependency checks outside of scheduled runs
+- Checking what updates are available without creating PRs (dry-run)
+- Validating custom managers or package rules
+
+## Quick Reference
+
+| Task | Command |
+|------|---------|
+| Dry-run (local, no PRs) | `npx renovate --platform=local --dry-run` |
+| Check specific repo | `npx renovate --dry-run owner/repo` |
+| Debug dependency detection | `npx renovate --log-level=debug --dry-run` |
+| Validate config | `npx renovate-config-validator` |
+| See detected dependencies | `LOG_LEVEL=debug npx renovate --dry-run 2>&1 \| grep -E "packageFile\|deps"` |
+
+## Installation
+
+```bash
+# Via npx (recommended for one-off runs)
+npx renovate --help
+
+# Global install
+npm install -g renovate
+
+# Via nix
+nix shell nixpkgs#renovate
+```
+
+## Common Workflows
+
+### 1. Test Configuration Locally
+
+```bash
+# Validate JSON syntax and schema
+npx renovate-config-validator renovate.json
+
+# Dry-run to see what Renovate would do
+npx renovate --platform=local --dry-run
+```
+
+### 2. Debug Dependency Detection
+
+```bash
+# Run with debug logging
+LOG_LEVEL=debug npx renovate --platform=local --dry-run 2>&1 | tee renovate-debug.log
+
+# Search for specific package
+grep -i "packageName" renovate-debug.log
+
+# Check which managers are running
+grep "manager" renovate-debug.log
+```
+
+### 3. Check for Available Updates
+
+```bash
+# Local dry-run shows all detected updates
+npx renovate --platform=local --dry-run
+
+# For a GitHub repo (requires token)
+RENOVATE_TOKEN=ghp_xxx npx renovate --dry-run owner/repo
+```
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `RENOVATE_TOKEN` | GitHub/GitLab token for API access |
+| `LOG_LEVEL` | `debug`, `info`, `warn`, `error` |
+| `RENOVATE_CONFIG_FILE` | Path to config file (default: `renovate.json`) |
+
+### Custom Manager Pattern
+
+For tracking versions in non-standard locations (like `ARG` in Dockerfiles):
+
+```json
+{
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Update VERSION ARG in Dockerfiles",
+      "fileMatch": ["(^|/)Dockerfile$"],
+      "matchStrings": [
+        "#\\s*renovate:\\s*datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\nARG \\w+=(?<currentValue>.*)"
+      ],
+      "versioningTemplate": "semver"
+    }
+  ]
+}
+```
+
+Then annotate your Dockerfile:
+
+```dockerfile
+# renovate: datasource=docker depName=myregistry.io/myimage
+ARG VERSION=1.2.3
+```
+
+## Datasources
+
+| Datasource | Use Case | Example depName |
+|------------|----------|-----------------|
+| `docker` | Container images | `python`, `nginx` |
+| `pypi` | Python packages | `requests`, `pandas` |
+| `npm` | Node packages | `lodash`, `express` |
+| `github-releases` | GitHub releases | `owner/repo` |
+| `github-tags` | GitHub tags | `owner/repo` |
+
+## Error Handling
+
+### "No token provided"
+
+```bash
+# Set token via environment
+export RENOVATE_TOKEN=ghp_your_token_here
+npx renovate owner/repo
+
+# Or use --platform=local for local-only testing
+npx renovate --platform=local --dry-run
+```
+
+### "Config validation failed"
+
+```bash
+# Validate config
+npx renovate-config-validator renovate.json
+
+# Check JSON syntax
+python3 -c "import json; json.load(open('renovate.json'))"
+```
+
+### "No dependencies found"
+
+```bash
+# Debug to see what files are being scanned
+LOG_LEVEL=debug npx renovate --platform=local --dry-run 2>&1 | grep -E "fileMatch|packageFile"
+```
+
+## Integration with GitHub Actions
+
+```yaml
+# .github/workflows/renovate.yml
+name: Renovate
+on:
+  schedule:
+    - cron: '0 5 * * 1'  # Weekly Monday 5am
+  workflow_dispatch:
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: renovatebot/github-action@v41
+        with:
+          configurationFile: renovate.json
+          token: ${{ secrets.RENOVATE_TOKEN }}
+```
+
+**Required PAT permissions:**
+- `contents: write` - create branches/commits
+- `pull-requests: write` - create PRs
+- `workflows: write` - update workflow files
+
+## References
+
+- [Renovate Docs](https://docs.renovatebot.com/)
+- [Configuration Options](https://docs.renovatebot.com/configuration-options/)
+- [Custom Managers](https://docs.renovatebot.com/modules/manager/regex/)
+- [Datasources](https://docs.renovatebot.com/modules/datasource/)
+- [GitHub Action](https://github.com/renovatebot/github-action)

--- a/cellxgene/Dockerfile
+++ b/cellxgene/Dockerfile
@@ -1,6 +1,7 @@
 # ---------------------------------------------------------------
 # 1) Multi-stage build: Pull the connect-client binary
 # ---------------------------------------------------------------
+# renovate: datasource=docker depName=public.cr.seqera.io/platform/connect-client
 ARG CONNECT_CLIENT_VERSION=0.9
 FROM public.cr.seqera.io/platform/connect-client:${CONNECT_CLIENT_VERSION} AS connect
 
@@ -27,6 +28,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Install CellxGene and its dependencies
+# renovate: datasource=pypi depName=cellxgene
 RUN pip install cellxgene==1.3.0
 
 # Define CellxGene dataset path and title with defaults

--- a/marimo/Dockerfile
+++ b/marimo/Dockerfile
@@ -1,6 +1,7 @@
 # ---------------------------------------------------------------
 # 1) Multi-stage build: Pull the connect-client binary
 # ---------------------------------------------------------------
+# renovate: datasource=docker depName=public.cr.seqera.io/platform/connect-client
 ARG CONNECT_CLIENT_VERSION=0.9
 FROM public.cr.seqera.io/platform/connect-client:${CONNECT_CLIENT_VERSION} AS connect
 
@@ -18,6 +19,7 @@ ENV UV_SYSTEM_PYTHON=1
 WORKDIR /app
 
 # Install the requirements using uv
+# renovate: datasource=pypi depName=marimo
 RUN uv pip install scikit-learn pandas altair micropip marimo==0.11.13
 
 # Define the port for the marimo server

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "description": "Renovate config for custom-studios-examples - manages Docker base images and connect-client versions",
+  "schedule": ["before 9am on monday"],
+  "timezone": "UTC",
+  "automerge": false,
+  "labels": ["dependencies"],
+  "prHourlyLimit": 5,
+  "prConcurrentLimit": 10,
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Update CONNECT_CLIENT_VERSION ARG in Dockerfiles",
+      "fileMatch": ["(^|/)Dockerfile$"],
+      "matchStrings": [
+        "#\\s*renovate:\\s*datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\nARG CONNECT_CLIENT_VERSION=(?<currentValue>.*)"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+    },
+    {
+      "customType": "regex",
+      "description": "Update connect_client_version default in GitHub workflow",
+      "fileMatch": ["^\\.github/workflows/.*\\.ya?ml$"],
+      "matchStrings": [
+        "#\\s*renovate:\\s*datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\n\\s+default:\\s*['\"]?(?<currentValue>[^'\"\\s]+)['\"]?"
+      ],
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "description": "Update pip packages with pinned versions",
+      "fileMatch": ["(^|/)Dockerfile$"],
+      "matchStrings": [
+        "#\\s*renovate:\\s*datasource=(?<datasource>.*?) depName=(?<depName>.*)\\n.*(?:pip install|uv pip install).*\\s\\S*==(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+      ],
+      "versioningTemplate": "semver"
+    }
+  ],
+  "packageRules": [
+    {
+      "description": "Group connect-client updates across all Dockerfiles",
+      "groupName": "connect-client",
+      "matchDepNames": ["public.cr.seqera.io/platform/connect-client"],
+      "matchManagers": ["regex", "dockerfile"]
+    },
+    {
+      "description": "Group Python base image updates",
+      "groupName": "python-base-images",
+      "matchDepNames": ["python"],
+      "matchManagers": ["dockerfile"]
+    },
+    {
+      "description": "Group GitHub Actions updates",
+      "groupName": "github-actions",
+      "matchManagers": ["github-actions"]
+    },
+    {
+      "description": "Update uv separately",
+      "groupName": "uv",
+      "matchDepNames": ["ghcr.io/astral-sh/uv"]
+    },
+    {
+      "description": "Update Wave images separately",
+      "groupName": "wave-images",
+      "matchDepPatterns": ["^community\\.wave\\.seqera\\.io/"]
+    },
+    {
+      "description": "Python pip packages",
+      "groupName": "python-packages",
+      "matchDatasources": ["pypi"]
+    }
+  ],
+  "dockerfile": {
+    "enabled": true
+  },
+  "github-actions": {
+    "enabled": true
+  }
+}

--- a/shiny-simple-example/Dockerfile
+++ b/shiny-simple-example/Dockerfile
@@ -1,6 +1,7 @@
 # ---------------------------------------------------------------
 # 1) Multi-stage build: Pull the connect-client binary
 # ---------------------------------------------------------------
+# renovate: datasource=docker depName=public.cr.seqera.io/platform/connect-client
 ARG CONNECT_CLIENT_VERSION=0.9
 FROM public.cr.seqera.io/platform/connect-client:${CONNECT_CLIENT_VERSION} AS connect
 

--- a/streamlit/Dockerfile
+++ b/streamlit/Dockerfile
@@ -1,6 +1,7 @@
 # ---------------------------------------------------------------
 # 1) Multi-stage build: Pull the connect-client binary
 # ---------------------------------------------------------------
+# renovate: datasource=docker depName=public.cr.seqera.io/platform/connect-client
 ARG CONNECT_CLIENT_VERSION=0.9
 FROM public.cr.seqera.io/platform/connect-client:${CONNECT_CLIENT_VERSION} AS connect
 

--- a/ttyd/Dockerfile
+++ b/ttyd/Dockerfile
@@ -1,6 +1,7 @@
 # ---------------------------------------------------------------
 # 1) Multi-stage build: Pull the connect-client binary
 # ---------------------------------------------------------------
+# renovate: datasource=docker depName=public.cr.seqera.io/platform/connect-client
 ARG CONNECT_CLIENT_VERSION=0.9
 FROM public.cr.seqera.io/platform/connect-client:${CONNECT_CLIENT_VERSION} AS connect
 


### PR DESCRIPTION
## Summary

- Add self-hosted Renovate via GitHub Action (free, runs on GHA runners)
- Configure automatic tracking of connect-client version across all Dockerfiles
- Group dependency updates by type for easier review

## Changes

- `renovate.json` - Main config with custom regex managers
- `.github/workflows/renovate.yml` - Weekly scheduled workflow
- All Dockerfiles updated with `# renovate:` comments for version tracking

## Dependency Groups

| Group | What it tracks |
|-------|----------------|
| `connect-client` | connect-client version in all Dockerfiles + workflow default |
| `python-base-images` | `python:3.x-slim` base images |
| `github-actions` | Action versions (`actions/checkout`, etc.) |
| `python-packages` | `cellxgene`, `marimo` pip packages |
| `uv` | `ghcr.io/astral-sh/uv` |
| `wave-images` | Wave container images |

## Setup Required

After merging, add a `RENOVATE_TOKEN` secret with a PAT that has:
- `contents: write`
- `pull-requests: write`  
- `workflows: write`

Then trigger the workflow manually or wait for the Monday schedule.