### PR TITLE
feat: auto-build studio images when Dockerfiles change

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,22 +3,29 @@ name: Build and Push Docker Images
 on:
   release:
     types: [published]
+  push:
+    branches:
+      - master
+    paths:
+      - '**/Dockerfile'
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag to use for the images (e.g., v1.0.0)'
-        required: true
+        description: 'Tag to use for the images (e.g., v1.0.0). Defaults to "latest"'
+        required: false
         type: string
+        default: 'latest'
+      # renovate: datasource=docker depName=public.cr.seqera.io/platform/connect-client
       connect_client_version:
         description: 'Version of connect-client to use (e.g., 0.9)'
-        required: true
+        required: false
         type: string
         default: '0.9'
 
 env:
   REGISTRY: ghcr.io
-  # Use release tag for releases, or input tag for manual runs
-  IMAGE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.tag }}
+  # Use release tag for releases, input tag for manual runs, or 'latest' for push
+  IMAGE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.tag || 'latest' }}
   # Use provided connect-client version or default to 0.9
   CONNECT_CLIENT_VERSION: ${{ inputs.connect_client_version || '0.9' }}
 
@@ -59,6 +66,7 @@ jobs:
         with:
           context: ${{ matrix.container.path }}
           push: true
+          platforms: linux/amd64
           build-args: |
             CONNECT_CLIENT_VERSION=${{ env.CONNECT_CLIENT_VERSION }}
           tags: |
@@ -69,5 +77,5 @@ jobs:
             org.opencontainers.image.description=Custom Studios Example Container for ${{ matrix.container.name }}
             org.opencontainers.image.licenses=MIT
             org.opencontainers.image.version=${{ env.IMAGE_TAG }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max 
+          cache-from: type=gha,scope=${{ matrix.container.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.container.name }} 


### PR DESCRIPTION
## Summary

- Auto-build and push studio images when any Dockerfile is edited on master
- Improves build caching with per-container scopes
- Adds explicit `linux/amd64` platform specification

## Changes

- Add `push` trigger on `master` branch for `**/Dockerfile` path changes
- Add `platforms: linux/amd64` to build step
- Improve GHA cache with `scope=${{ matrix.container.name }}`
- Make `tag` input optional (defaults to `latest`)
- Add renovate comment for `connect_client_version` tracking

## Workflow Triggers

| Trigger | Tag | When |
|---------|-----|------|
| Push to master (Dockerfile change) | `latest` | Automatic |
| Manual dispatch | User-specified or `latest` | On demand |
| Release published | Release tag | On release |

## Testing

After merge, the workflow will automatically trigger and build all 5 studio images:
- `ghcr.io/seqeralabs/custom-studios-examples/cellxgene:latest`
- `ghcr.io/seqeralabs/custom-studios-examples/marimo:latest`
- `ghcr.io/seqeralabs/custom-studios-examples/streamlit:latest`
- `ghcr.io/seqeralabs/custom-studios-examples/shiny-simple-example:latest`
- `ghcr.io/seqeralabs/custom-studios-examples/ttyd:latest`