### PR TITLE
👷 ci: add PR image builds with automatic cleanup

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,6 +8,9 @@ on:
       - master
     paths:
       - '**/Dockerfile'
+  pull_request:
+    paths:
+      - '**/Dockerfile'
   workflow_dispatch:
     inputs:
       tag:
@@ -24,27 +27,29 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  # Use release tag for releases, input tag for manual runs, or 'latest' for push
-  IMAGE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.tag || 'latest' }}
   # Use provided connect-client version or default to 0.9
   CONNECT_CLIENT_VERSION: ${{ inputs.connect_client_version || '0.9' }}
 
 jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Define container matrix
+        id: set-matrix
+        run: |
+          echo 'matrix={"container":[{"name":"ttyd","path":"./ttyd"},{"name":"streamlit","path":"./streamlit"},{"name":"cellxgene","path":"./cellxgene"},{"name":"shiny","path":"./shiny-simple-example"},{"name":"marimo","path":"./marimo"}]}' >> "$GITHUB_OUTPUT"
+
   build-and-push:
     runs-on: ubuntu-latest
+    needs: setup
     permissions:
       contents: read
       packages: write
-    
+
     strategy:
-      matrix:
-        container: [
-          { name: 'ttyd', path: './ttyd' },
-          { name: 'streamlit', path: './streamlit' },
-          { name: 'cellxgene', path: './cellxgene' },
-          { name: 'shiny', path: './shiny-simple-example' },
-          { name: 'marimo', path: './marimo' }
-        ]
+      matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
       fail-fast: false
 
     steps:
@@ -61,6 +66,23 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Determine image tag
+        id: image-tag
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "tag=pr-${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+            echo "is_pr=true" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.event_name }}" == "release" ]]; then
+            echo "tag=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+            echo "is_pr=false" >> "$GITHUB_OUTPUT"
+          elif [[ -n "${{ inputs.tag }}" && "${{ inputs.tag }}" != "latest" ]]; then
+            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+            echo "is_pr=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+            echo "is_pr=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Build and push ${{ matrix.container.name }}
         uses: docker/build-push-action@v5
         with:
@@ -70,12 +92,74 @@ jobs:
           build-args: |
             CONNECT_CLIENT_VERSION=${{ env.CONNECT_CLIENT_VERSION }}
           tags: |
-            ${{ env.REGISTRY }}/${{ github.repository }}/${{ matrix.container.name }}:${{ env.IMAGE_TAG }}
-            ${{ env.REGISTRY }}/${{ github.repository }}/${{ matrix.container.name }}:latest
+            ${{ env.REGISTRY }}/${{ github.repository }}/${{ matrix.container.name }}:${{ steps.image-tag.outputs.tag }}
+            ${{ steps.image-tag.outputs.is_pr == 'false' && format('{0}/{1}/{2}:latest', env.REGISTRY, github.repository, matrix.container.name) || '' }}
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.description=Custom Studios Example Container for ${{ matrix.container.name }}
             org.opencontainers.image.licenses=MIT
-            org.opencontainers.image.version=${{ env.IMAGE_TAG }}
+            org.opencontainers.image.version=${{ steps.image-tag.outputs.tag }}
           cache-from: type=gha,scope=${{ matrix.container.name }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.container.name }} 
+          cache-to: type=gha,mode=max,scope=${{ matrix.container.name }}
+
+  cleanup-pr-images:
+    runs-on: ubuntu-latest
+    needs: [setup, build-and-push]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    permissions:
+      packages: write
+
+    strategy:
+      matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
+
+    steps:
+      - name: Extract PR number from merge commit
+        id: extract-pr
+        env:
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+        run: |
+          # Extract PR number from merge commit message (format: "Merge pull request #123 from...")
+          PR_NUMBER=$(echo "$COMMIT_MESSAGE" | grep -oP 'Merge pull request #\K[0-9]+' || echo "")
+          if [[ -z "$PR_NUMBER" ]]; then
+            echo "No PR number found in commit message, skipping cleanup"
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Found PR number: $PR_NUMBER"
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Delete PR image for ${{ matrix.container.name }}
+        if: steps.extract-pr.outputs.found == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GHCR_TOKEN }}
+          PR_NUMBER: ${{ steps.extract-pr.outputs.number }}
+          CONTAINER_NAME: ${{ matrix.container.name }}
+        run: |
+          PACKAGE_NAME="custom-studios-examples/${CONTAINER_NAME}"
+          TAG="pr-${PR_NUMBER}"
+
+          echo "Checking for $PACKAGE_NAME:$TAG..."
+
+          # Get all versions of the package
+          VERSIONS=$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "/orgs/seqeralabs/packages/container/${PACKAGE_NAME}/versions" \
+            --paginate 2>/dev/null || echo "[]")
+
+          # Find the version ID for our PR tag
+          VERSION_ID=$(echo "$VERSIONS" | jq -r ".[] | select(.metadata.container.tags[] == \"$TAG\") | .id" 2>/dev/null || echo "")
+
+          if [[ -n "$VERSION_ID" ]]; then
+            echo "Deleting $PACKAGE_NAME:$TAG (version ID: $VERSION_ID)..."
+            gh api \
+              --method DELETE \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "/orgs/seqeralabs/packages/container/${PACKAGE_NAME}/versions/${VERSION_ID}" \
+              && echo "Successfully deleted $PACKAGE_NAME:$TAG" \
+              || echo "Failed to delete $PACKAGE_NAME:$TAG (may not exist)"
+          else
+            echo "No image found for $PACKAGE_NAME:$TAG, skipping"
+          fi


### PR DESCRIPTION
## Summary
- Enable testing PR changes by building container images tagged `pr-<number>` when Dockerfiles are modified
- Automatically clean up PR images from GHCR when PRs are merged to master
- Refactor workflow to define container matrix once and reuse across jobs

## Changes
- Add `pull_request` trigger filtered to Dockerfile changes
- Add `setup` job that outputs the container matrix as JSON
- Update `build-and-push` to use dynamic tagging (PR builds get `pr-X`, others get version + latest)
- Add `cleanup-pr-images` job that extracts PR number from merge commits and deletes associated images

🤖 Generated with [Claude Code](https://claude.ai/code)