### PR TITLE
chore:Split image registries

### DIFF
--- a/.github/workflows/cleanup-pr-images.yml
+++ b/.github/workflows/cleanup-pr-images.yml
@@ -23,12 +23,12 @@ jobs:
 
     steps:
       # TODO: Enable once GHCR_TOKEN has delete:packages scope
-      - name: Delete PR image for ${{ matrix.container.name }}
+      - name: Delete PR image for ${{ matrix.container.name }}-dev
         if: false
         env:
           GH_TOKEN: ${{ secrets.GHCR_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          CONTAINER_NAME: ${{ matrix.container.name }}
+          CONTAINER_NAME: ${{ matrix.container.name }}-dev
         run: |
           PACKAGE_NAME="custom-studios-examples/${CONTAINER_NAME}"
           TAG="pr-${PR_NUMBER}"

--- a/.github/workflows/cleanup-pr-images.yml
+++ b/.github/workflows/cleanup-pr-images.yml
@@ -23,15 +23,15 @@ jobs:
 
     steps:
       # TODO: Enable once GHCR_TOKEN has delete:packages scope
-      - name: Delete PR image for ${{ matrix.container.name }}-dev
+      - name: Delete PR image for ${{ matrix.container.name }}
         if: false
         env:
           GH_TOKEN: ${{ secrets.GHCR_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          CONTAINER_NAME: ${{ matrix.container.name }}-dev
+          CONTAINER_NAME: ${{ matrix.container.name }}
         run: |
-          PACKAGE_NAME="custom-studios-examples/${CONTAINER_NAME}"
-          TAG="pr-${PR_NUMBER}"
+          PACKAGE_NAME="custom-studios-examples/development"
+          TAG="${CONTAINER_NAME}-pr${PR_NUMBER}"
 
           echo "Checking for $PACKAGE_NAME:$TAG..."
 

--- a/.github/workflows/cleanup-pr-images.yml
+++ b/.github/workflows/cleanup-pr-images.yml
@@ -12,28 +12,15 @@ jobs:
       contents: read
       packages: write
 
-    strategy:
-      matrix:
-        container:
-          - name: ttyd
-          - name: streamlit
-          - name: cellxgene
-          - name: shiny
-          - name: marimo
-
     steps:
-      # TODO: Enable once GHCR_TOKEN has delete:packages scope
-      - name: Delete PR image for ${{ matrix.container.name }}
-        if: false
+      - name: Cleanup PR images
         env:
           GH_TOKEN: ${{ secrets.GHCR_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          CONTAINER_NAME: ${{ matrix.container.name }}
         run: |
           PACKAGE_NAME="custom-studios-examples/development"
-          TAG="${CONTAINER_NAME}-pr${PR_NUMBER}"
 
-          echo "Checking for $PACKAGE_NAME:$TAG..."
+          echo "Cleaning up images for PR #${PR_NUMBER}..."
 
           # Get all versions of the package
           VERSIONS=$(gh api \
@@ -42,18 +29,23 @@ jobs:
             "/orgs/seqeralabs/packages/container/${PACKAGE_NAME}/versions" \
             --paginate 2>/dev/null || echo "[]")
 
-          # Find the version ID for our PR tag
-          VERSION_ID=$(echo "$VERSIONS" | jq -r ".[] | select(.metadata.container.tags[] == \"$TAG\") | .id" 2>/dev/null || echo "")
+          # Find all versions with tags ending in -pr<PR_NUMBER>
+          echo "$VERSIONS" | jq -r --arg pr "pr${PR_NUMBER}" '
+            .[] |
+            select(.metadata.container.tags[] | endswith("-" + $pr)) |
+            .id
+          ' | while read -r VERSION_ID; do
+            if [[ -n "$VERSION_ID" ]]; then
+              TAGS=$(echo "$VERSIONS" | jq -r --arg id "$VERSION_ID" '.[] | select(.id == ($id | tonumber)) | .metadata.container.tags | join(", ")')
+              echo "Deleting version $VERSION_ID (tags: $TAGS)..."
+              gh api \
+                --method DELETE \
+                -H "Accept: application/vnd.github+json" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                "/orgs/seqeralabs/packages/container/${PACKAGE_NAME}/versions/${VERSION_ID}" \
+                && echo "Successfully deleted" \
+                || echo "Failed to delete"
+            fi
+          done
 
-          if [[ -n "$VERSION_ID" ]]; then
-            echo "Deleting $PACKAGE_NAME:$TAG (version ID: $VERSION_ID)..."
-            gh api \
-              --method DELETE \
-              -H "Accept: application/vnd.github+json" \
-              -H "X-GitHub-Api-Version: 2022-11-28" \
-              "/orgs/seqeralabs/packages/container/${PACKAGE_NAME}/versions/${VERSION_ID}" \
-              && echo "Successfully deleted $PACKAGE_NAME:$TAG" \
-              || echo "Failed to delete $PACKAGE_NAME:$TAG (may not exist)"
-          else
-            echo "No image found for $PACKAGE_NAME:$TAG, skipping"
-          fi
+          echo "Cleanup complete for PR #${PR_NUMBER}"

--- a/.github/workflows/docker-pr.yml
+++ b/.github/workflows/docker-pr.yml
@@ -61,6 +61,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      pull-requests: write
 
     strategy:
       fail-fast: false
@@ -84,9 +85,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ github.repository }}/${{ matrix.container.name }}-dev
+          images: ${{ env.REGISTRY }}/${{ github.repository }}/development
           tags: |
-            type=ref,event=pr,prefix=pr-
+            type=ref,event=pr,prefix=${{ matrix.container.name }}-pr
 
       - name: Build and push ${{ matrix.container.name }}
         uses: docker/build-push-action@v5
@@ -98,3 +99,122 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=${{ matrix.container.name }}
           cache-to: type=gha,mode=max,scope=${{ matrix.container.name }}
+
+      - name: Get image reference for scan
+        id: scanref
+        run: |
+          echo "ref=${{ fromJSON(steps.meta.outputs.json).tags[0] }}" >> $GITHUB_OUTPUT
+
+      - name: Run security scan
+        uses: aquasecurity/trivy-action@0.31.0
+        with:
+          image-ref: ${{ steps.scanref.outputs.ref }}
+          format: "table"
+          output: "trivy-results.txt"
+          severity: "CRITICAL,HIGH,MEDIUM"
+          exit-code: "0"
+
+      - name: Display security scan results
+        if: always()
+        run: |
+          echo "## 🔒 Security Scan Results - ${{ matrix.container.name }}" >> $GITHUB_STEP_SUMMARY
+          if [ -f trivy-results.txt ]; then
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            cat trivy-results.txt >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+          else
+            echo "No security scan results found" >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Upload security scan results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: trivy-scan-${{ matrix.container.name }}-${{ github.run_id }}
+          path: trivy-results.txt
+          retention-days: 30
+
+      - name: Generate build summary
+        if: always()
+        run: |
+          echo "## 🐳 Build Summary - ${{ matrix.container.name }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Image**: \`${{ env.REGISTRY }}/${{ github.repository }}/development\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **Tag**: \`${{ matrix.container.name }}-pr${{ github.event.pull_request.number }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **Branch**: ${{ github.head_ref }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Commit**: \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
+
+      - name: Comment on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const imageName = '${{ matrix.container.name }}';
+            const imageTag = `${{ env.REGISTRY }}/${{ github.repository }}/development:${imageName}-pr${{ github.event.pull_request.number }}`;
+            const commentId = `build-results-${imageName}`;
+
+            let securityStatus = '✅ Security scan completed';
+            try {
+              if (fs.existsSync('trivy-results.txt')) {
+                const results = fs.readFileSync('trivy-results.txt', 'utf8');
+                const lines = results.split('\n');
+                const criticalCount = lines.filter(line => line.includes('CRITICAL')).length;
+                const highCount = lines.filter(line => line.includes('HIGH')).length;
+                const mediumCount = lines.filter(line => line.includes('MEDIUM')).length;
+
+                if (criticalCount > 0 || highCount > 0) {
+                  securityStatus = `⚠️ Found ${criticalCount} critical, ${highCount} high, ${mediumCount} medium vulnerabilities`;
+                } else if (mediumCount > 0) {
+                  securityStatus = `✅ ${mediumCount} medium vulnerabilities found`;
+                } else {
+                  securityStatus = '✅ No vulnerabilities found';
+                }
+              }
+            } catch (e) {
+              securityStatus = '⚠️ Security scan results could not be parsed';
+            }
+
+            const output = `## 🐳 Docker Build Results - ${imageName}
+
+            ✅ Docker image built successfully
+
+            | Property | Value |
+            |----------|-------|
+            | **Image** | \`${imageTag}\` |
+            | **Branch** | ${{ github.head_ref }} |
+            | **Commit** | \`${{ github.sha }}\` |
+            | **Security** | ${securityStatus} |
+
+            \`\`\`bash
+            docker pull ${imageTag}
+            \`\`\`
+
+            📁 Download the full security scan report from the workflow artifacts.
+
+            <!-- ${commentId} -->`;
+
+            const comments = await github.rest.issues.listComments({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+
+            const existingComment = comments.data.find(comment =>
+              comment.body.includes(`<!-- ${commentId} -->`)
+            );
+
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                comment_id: existingComment.id,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: output
+              });
+            } else {
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: output
+              });
+            }

--- a/.github/workflows/docker-pr.yml
+++ b/.github/workflows/docker-pr.yml
@@ -84,7 +84,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ github.repository }}/${{ matrix.container.name }}
+          images: ${{ env.REGISTRY }}/${{ github.repository }}/${{ matrix.container.name }}-dev
           tags: |
             type=ref,event=pr,prefix=pr-
 

--- a/marimo/Dockerfile
+++ b/marimo/Dockerfile
@@ -1,6 +1,7 @@
 # ---------------------------------------------------------------
 # 1) Multi-stage build: Pull the connect-client binary
 # ---------------------------------------------------------------
+# Test Build
 ARG CONNECT_CLIENT_VERSION=0.9
 FROM public.cr.seqera.io/platform/connect-client:${CONNECT_CLIENT_VERSION} AS connect
 


### PR DESCRIPTION
The following adds a new image registry called "ghcr.io/.../development:<container>-pr<number>"

This means that our core package repositories are not polluted by pull request workflows. 

Along with relevant PR comments and scanning to give feedback to consumers on the contents and where to test images. 