### PR TITLE
Use registry cache for Docker workflows

### DIFF
--- a/.github/workflows/docker-pr.yml
+++ b/.github/workflows/docker-pr.yml
@@ -77,8 +77,8 @@ jobs:
           platforms: linux/amd64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=${{ matrix.container.name }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.container.name }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}/development:${{ matrix.container.name }}-buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}/development:${{ matrix.container.name }}-buildcache,mode=max
 
       - name: Get image reference for scan
         id: scanref

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -73,8 +73,8 @@ jobs:
             CONNECT_CLIENT_VERSION=${{ inputs.connect_client_version || '0.9' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=${{ inputs.container }}
-          cache-to: type=gha,mode=max,scope=${{ inputs.container }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}/${{ inputs.container }}:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}/${{ inputs.container }}:buildcache,mode=max
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Replace Docker Buildx GitHub Actions cache backend with GHCR registry cache refs in PR and release image workflows.
- Keep workflow action `uses:` references pinned to full commit SHAs.

### Testing
- Passed focused workflow validation confirming all workflow `uses:` refs are full 40-character SHAs.
- Passed focused scan confirming no `actions/cache@`, `type=gha`, or tag-pinned `uses: ...@vN` references remain.
- Passed YAML syntax parsing for all workflow files.
- `actionlint` is not installed in this environment; no native actionlint pass was available.
- GitHub reported no PR checks yet for this branch at validation time.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f7aee8f-7f0e-407e-9272-d020e96842f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f7aee8f-7f0e-407e-9272-d020e96842f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

