### PR TITLE
Improve QuPath KasmVNC responsiveness and readability

### DIFF
--- a/.seqera/Dockerfile
+++ b/.seqera/Dockerfile
@@ -14,11 +14,9 @@ LABEL org.opencontainers.image.source="https://github.com/seqeralabs/custom-stud
 
 ENV TITLE="QuPath"
 
-# A fixed, laptop-friendly desktop prevents a large client display from
-# negotiating a huge remote canvas with tiny QuPath controls. These values can
-# still be overridden in the Studio environment when a different display is
-# required.
-ENV VNC_RESOLUTION=1440x900 \
+# The remote desktop follows the browser size. QuPath's interface is scaled
+# separately by the launcher, so controls remain readable on large displays.
+ENV QUPATH_UI_SCALE=1.5 \
     KASMVNC_FRAME_RATE=30 \
     KASMVNC_RECT_THREADS=4 \
     KASMVNC_DYNAMIC_QUALITY_MIN=7 \
@@ -45,6 +43,14 @@ RUN wget -q https://github.com/qupath/qupath/releases/download/v${QUPATH_VERSION
     && chmod +x /opt/qupath/bin/QuPath \
     && rm /tmp/qupath.tar.xz
 
+# Scale QuPath's JavaFX interface without constraining the remote desktop.
+RUN printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'export JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS:-} -Dglass.gtk.uiScale=${QUPATH_UI_SCALE:-1.5}"' \
+    'exec /opt/qupath/bin/QuPath "$@"' \
+    > /usr/local/bin/start-qupath \
+    && chmod +x /usr/local/bin/start-qupath
+
 # Override the base image's KasmVNC service with settings it actually consumes.
 COPY kasmvnc-run /etc/s6-overlay/s6-rc.d/svc-kasmvnc/run
 RUN chmod +x /etc/s6-overlay/s6-rc.d/svc-kasmvnc/run
@@ -59,7 +65,7 @@ RUN chmod +x /etc/s6-overlay/s6-rc.d/svc-studio-proxy/run \
     && touch /etc/s6-overlay/s6-rc.d/user/contents.d/svc-studio-proxy
 
 # Single-app mode: application launches directly, no desktop.
-RUN echo "/opt/qupath/bin/QuPath" > /defaults/autostart
+RUN echo "/usr/local/bin/start-qupath" > /defaults/autostart
 
 # ---------------------------------------------------------------
 # 3) Seqera Studios integration

--- a/.seqera/Dockerfile
+++ b/.seqera/Dockerfile
@@ -14,11 +14,15 @@ LABEL org.opencontainers.image.source="https://github.com/seqeralabs/custom-stud
 
 ENV TITLE="QuPath"
 
-# KasmVNC performance tuning for interactive desktop streaming
-ENV KASM_VNC_ENABLE_WEBP=1
-ENV KASM_VNC_JPEG_QUALITY=5
-ENV KASM_VNC_MAX_FRAME_RATE=30
-ENV KASM_VNC_THREADS=4
+# A fixed, laptop-friendly desktop prevents a large client display from
+# negotiating a huge remote canvas with tiny QuPath controls. These values can
+# still be overridden in the Studio environment when a different display is
+# required.
+ENV VNC_RESOLUTION=1440x900 \
+    KASMVNC_FRAME_RATE=30 \
+    KASMVNC_RECT_THREADS=4 \
+    KASMVNC_DYNAMIC_QUALITY_MIN=7 \
+    KASMVNC_DYNAMIC_QUALITY_MAX=8
 
 # Install dependencies for QuPath. The base image can carry stale third-party apt
 # sources, so drop NodeSource before refreshing Ubuntu package indexes.
@@ -41,8 +45,9 @@ RUN wget -q https://github.com/qupath/qupath/releases/download/v${QUPATH_VERSION
     && chmod +x /opt/qupath/bin/QuPath \
     && rm /tmp/qupath.tar.xz
 
-# Create the X socket directory before KasmVNC drops privileges to the abc user.
-RUN sed -i '/^exec s6-setuidgid/i mkdir -p /tmp/.X11-unix && chmod 1777 /tmp/.X11-unix' /etc/s6-overlay/s6-rc.d/svc-kasmvnc/run
+# Override the base image's KasmVNC service with settings it actually consumes.
+COPY kasmvnc-run /etc/s6-overlay/s6-rc.d/svc-kasmvnc/run
+RUN chmod +x /etc/s6-overlay/s6-rc.d/svc-kasmvnc/run
 
 # Start a Studio-facing proxy as soon as s6 launches. KasmVNC takes a short time
 # to warm up, and this keeps first-time connections from seeing a platform 502.

--- a/.seqera/kasmvnc-run
+++ b/.seqera/kasmvnc-run
@@ -20,8 +20,8 @@ exec s6-setuidgid abc \
     -AlwaysShared \
     -http-header Cross-Origin-Embedder-Policy=require-corp \
     -http-header Cross-Origin-Opener-Policy=same-origin \
-    -geometry "${VNC_RESOLUTION:-1440x900}" \
-    -AcceptSetDesktopSize=0 \
+    -geometry 1024x768 \
+    -AcceptSetDesktopSize=1 \
     -sslOnly 0 \
     -RectThreads "${KASMVNC_RECT_THREADS:-4}" \
     -FrameRate "${KASMVNC_FRAME_RATE:-30}" \

--- a/.seqera/kasmvnc-run
+++ b/.seqera/kasmvnc-run
@@ -1,0 +1,32 @@
+#!/usr/bin/with-contenv bash
+
+# Keep the LinuxServer KasmVNC service behavior while making the display and
+# stream settings explicit and overridable through the Studio environment.
+if ls /dev/dri/renderD* > /dev/null 2>&1 && [ -z "${DISABLE_DRI+x}" ] && ! command -v nvidia-smi > /dev/null; then
+    HW3D="-hw3d"
+fi
+
+: "${DRINODE:=/dev/dri/renderD128}"
+mkdir -p /tmp/.X11-unix
+chmod 1777 /tmp/.X11-unix
+
+exec s6-setuidgid abc \
+    /usr/local/bin/Xvnc "$DISPLAY" \
+    ${HW3D:-} \
+    -PublicIP 127.0.0.1 \
+    -drinode "$DRINODE" \
+    -disableBasicAuth \
+    -SecurityTypes None \
+    -AlwaysShared \
+    -http-header Cross-Origin-Embedder-Policy=require-corp \
+    -http-header Cross-Origin-Opener-Policy=same-origin \
+    -geometry "${VNC_RESOLUTION:-1440x900}" \
+    -AcceptSetDesktopSize=0 \
+    -sslOnly 0 \
+    -RectThreads "${KASMVNC_RECT_THREADS:-4}" \
+    -FrameRate "${KASMVNC_FRAME_RATE:-30}" \
+    -DynamicQualityMin "${KASMVNC_DYNAMIC_QUALITY_MIN:-7}" \
+    -DynamicQualityMax "${KASMVNC_DYNAMIC_QUALITY_MAX:-8}" \
+    -websocketPort 6901 \
+    -interface 0.0.0.0 \
+    -Log '*:stdout:10'

--- a/README.md
+++ b/README.md
@@ -37,19 +37,20 @@ wave -f .seqera/Dockerfile --context .seqera --platform linux/amd64 --await --to
 - QuPath 0.6.0 bioimage analysis desktop
 - Browser access through LinuxServer.io KasmVNC
 - Single-app mode that launches QuPath directly
-- A fixed 1440×900 desktop so QuPath controls remain readable on large displays
+- A desktop that expands to fill the browser window
+- A 1.5× QuPath interface scale so controls remain readable on large displays
 - 30 FPS streaming, four compression threads, and high-quality text updates for responsive interaction
 - Startup proxy that serves a loading page until KasmVNC is ready, avoiding first-load 502 errors
 
 ## Display and streaming defaults
 
-The Studio defaults to a 1440×900 desktop. This keeps the QuPath interface readable on high-resolution displays rather than allowing the browser to negotiate an oversized remote desktop.
+KasmVNC resizes the remote desktop to fill the browser window. QuPath's JavaFX interface is scaled independently, so the extra space does not make its menus and controls too small.
 
 For a different environment, override any of these Studio environment variables:
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
-| `VNC_RESOLUTION` | `1440x900` | Fixed remote desktop size, as `WIDTHxHEIGHT` |
+| `QUPATH_UI_SCALE` | `1.5` | QuPath interface scale; use `1.0` for standard density or increase it for high-density displays |
 | `KASMVNC_FRAME_RATE` | `30` | Maximum streamed frames per second |
 | `KASMVNC_RECT_THREADS` | `4` | Parallel compression threads |
 | `KASMVNC_DYNAMIC_QUALITY_MIN` | `7` | Lowest quality used while the screen is changing |

--- a/README.md
+++ b/README.md
@@ -37,8 +37,23 @@ wave -f .seqera/Dockerfile --context .seqera --platform linux/amd64 --await --to
 - QuPath 0.6.0 bioimage analysis desktop
 - Browser access through LinuxServer.io KasmVNC
 - Single-app mode that launches QuPath directly
-- KasmVNC WebP, quality, frame-rate, and thread tuning for interactive use
+- A fixed 1440×900 desktop so QuPath controls remain readable on large displays
+- 30 FPS streaming, four compression threads, and high-quality text updates for responsive interaction
 - Startup proxy that serves a loading page until KasmVNC is ready, avoiding first-load 502 errors
+
+## Display and streaming defaults
+
+The Studio defaults to a 1440×900 desktop. This keeps the QuPath interface readable on high-resolution displays rather than allowing the browser to negotiate an oversized remote desktop.
+
+For a different environment, override any of these Studio environment variables:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `VNC_RESOLUTION` | `1440x900` | Fixed remote desktop size, as `WIDTHxHEIGHT` |
+| `KASMVNC_FRAME_RATE` | `30` | Maximum streamed frames per second |
+| `KASMVNC_RECT_THREADS` | `4` | Parallel compression threads |
+| `KASMVNC_DYNAMIC_QUALITY_MIN` | `7` | Lowest quality used while the screen is changing |
+| `KASMVNC_DYNAMIC_QUALITY_MAX` | `8` | Quality used for mostly static content such as text |
 
 ## References
 


### PR DESCRIPTION
## Summary

Improves the QuPath single-application Studio defaults for readability and interaction responsiveness.

- Lets KasmVNC resize the remote desktop to fill the browser window.
- Scales QuPath’s JavaFX interface independently at 1.5×, keeping menus and controls readable on large displays.
- Configures the KasmVNC service directly with a 30 FPS cap, four compression threads, and high-quality text updates.
- Documents display and streaming overrides.

## Root cause

The first version fixed the remote desktop size, which improved perceived UI scale but left unused canvas around the application. The revision restores adaptive desktop resizing and moves the readability adjustment into QuPath itself.

## Validation

- `bash -n .seqera/kasmvnc-run`
- `git diff --check`

A container runtime was not available locally, so the image was not launched in this workspace.