### PR TITLE
📝 docs: list the desktop studios in the master README

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Guidance for AI coding agents working in this repository.
 
 ## Repository overview
 
-This is **Seqera Labs Custom Studios Examples** — a collection of Docker-based [Seqera Platform Studios](https://docs.seqera.io/platform-cloud/studios/overview) reference environments. Each studio is a standalone container image (Marimo, CellxGene, Streamlit, R Shiny, Shinyngs, TTYD). There is no root-level package manager, monorepo build, or docker-compose stack.
+This is **Seqera Labs Custom Studios Examples** — a collection of Docker-based [Seqera Platform Studios](https://docs.seqera.io/platform-cloud/studios/overview) reference environments. Each studio is a standalone container image (Marimo, CellxGene, Streamlit, R Shiny, Shinyngs, TTYD, and the branch-only desktop studios QuPath/KasmVNC and Selkies Webtop). There is no root-level package manager, monorepo build, or docker-compose stack.
 
 The `master` branch holds documentation and example directories. Deployable studio configs (`.seqera/studio-config.yaml`) live on dedicated git branches per studio.
 

--- a/README.md
+++ b/README.md
@@ -18,13 +18,15 @@ This repository uses a **branch-per-studio** model (similar to [nf-core/test-dat
 | [`shiny`](https://github.com/seqeralabs/custom-studios-examples/tree/shiny) | R Shiny | Interactive data visualization with R Shiny |
 | [`shinyngs`](https://github.com/seqeralabs/custom-studios-examples/tree/shinyngs) | Shinyngs | RNA-seq exploration with the `shinyngs` R package |
 | [`ttyd`](https://github.com/seqeralabs/custom-studios-examples/tree/ttyd) | TTYD | Web-based terminal with bioinformatics tools |
+| [`kasmvnc-qupath`](https://github.com/seqeralabs/custom-studios-examples/tree/kasmvnc-qupath) | QuPath | Bioimage analysis desktop app streamed with KasmVNC |
+| [`selkies-webtop`](https://github.com/seqeralabs/custom-studios-examples/tree/selkies-webtop) | Selkies Webtop | Full Debian XFCE desktop streamed with Selkies |
 
 ## Quick Start: Launch from Git Repository
 
 1. Navigate to **Studios** > **Add Studio** in your Seqera Platform workspace
 2. Select **Git repository** as the source
 3. Enter the repository URL: `https://github.com/seqeralabs/custom-studios-examples`
-4. Select the branch for the studio you want (e.g., `marimo`, `cellxgene`, `streamlit`, `shiny`, `shinyngs`, `ttyd`)
+4. Select the branch for the studio you want (e.g., `marimo`, `cellxgene`, `streamlit`, `shiny`, `shinyngs`, `ttyd`, `kasmvnc-qupath`, `selkies-webtop`)
 5. Select your compute environment
 6. Click **Add** then **Start**
 
@@ -35,7 +37,7 @@ Each branch contains a `.seqera/` directory with:
 
 ## Alternative Deployment: Pre-built Images
 
-Each studio is also available as a pre-built container image:
+These studios are also available as pre-built container images:
 
 ```
 ghcr.io/seqeralabs/custom-studios-examples/marimo:latest
@@ -47,6 +49,8 @@ ghcr.io/seqeralabs/custom-studios-examples/ttyd:latest
 ```
 
 To use a pre-built image, select **Prebuilt container image** instead of **Git repository** when adding a Studio.
+
+The desktop studios (`kasmvnc-qupath`, `selkies-webtop`) have no pre-built image; add them from their Git branch, or build them with the Wave CLI.
 
 ## Alternative Deployment: Wave CLI
 
@@ -88,6 +92,8 @@ Some studios support environment variable configuration:
 | Shiny | `DATA_PATH` | `s3://shiny-inputs/data.csv` | Path to CSV data file |
 
 Studios without listed variables (Marimo, Shinyngs, Streamlit, TTYD) work with their default configurations.
+
+The desktop studios expose display and streaming variables instead of data paths — QuPath's interface scale and KasmVNC frame rate and compression, and Selkies' DPI and startup behavior. Those are documented in the [`kasmvnc-qupath`](https://github.com/seqeralabs/custom-studios-examples/blob/kasmvnc-qupath/README.md) and [`selkies-webtop`](https://github.com/seqeralabs/custom-studios-examples/blob/selkies-webtop/README.md) branch READMEs.
 
 ## Common Features
 


### PR DESCRIPTION
Documents the two desktop studios on `master`, so they are discoverable alongside the rest.

## Changes

- **Available Studios**: adds [`selkies-webtop`](https://github.com/seqeralabs/custom-studios-examples/tree/selkies-webtop) (full Debian XFCE desktop through Selkies) and [`kasmvnc-qupath`](https://github.com/seqeralabs/custom-studios-examples/tree/kasmvnc-qupath) (QuPath through KasmVNC). The QuPath branch shipped a while ago but was never listed here.
- **Quick Start**: both branch names added to the example list in step 4.
- **Pre-built Images**: neither desktop studio has a GHCR image — `docker-release.yml` builds from the studio *directories* still on `master`, not from studio branches — so the section now says which studios it covers and points the desktop ones at their Git branch or the Wave CLI.
- **Environment Variables**: the desktop studios expose display and streaming variables rather than data paths, so this links their branch READMEs instead of duplicating the tables here.
- **AGENTS.md**: studio list updated to match.

Docs only. No studio configuration is added to `master`.

## Related

The `selkies-webtop` branch was renamed from `feat/selkies-webtop` to match the naming of the other studio branches, so the links above resolve.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
